### PR TITLE
Add YAML build tests

### DIFF
--- a/examples/loaders/preprocessor-yaml.js
+++ b/examples/loaders/preprocessor-yaml.js
@@ -4,7 +4,7 @@ import yaml from 'yaml';
 
 export const sourceExtensionTypes = ['.yaml', '.yml'];
 
-export const outputExtensionTypes = ['.json'];
+export const outputExtensionTypes = ['.js'];
 
 export function getPreProcessor(options = {}) {
   return {

--- a/loaderconfig.json
+++ b/loaderconfig.json
@@ -24,10 +24,5 @@
       }
     }
   ],
-  "postProcessors": [
-    {
-      "name": "../examples/loaders/postprocessor-consolelog.js",
-      "options": {}
-    }
-  ]
+  "postProcessors": []
 }

--- a/tap-snapshots/test-system-yaml.js-TAP.test.js
+++ b/tap-snapshots/test-system-yaml.js-TAP.test.js
@@ -5,6 +5,24 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/system/yaml.js TAP YAML System Tests > [YAML Build] - Correct output source code 1`] = `
+import yamlFile from './yamlExample.js';
+
+console.log('YAML as JSON: \\n', yamlFile);
+
+`
+
+exports[`test/system/yaml.js TAP YAML System Tests > [YAML Build] - Correct output source code 2`] = `
+export default {"Employees":[{"John Doe":{"job":"SWE","skills":["python","java"]}},{"Jane Doe":{"job":"SWE","skills":["java","python","php"]}}]}
+`
+
+exports[`test/system/yaml.js TAP YAML System Tests > [YAML Build] - Correct output tree file names 1`] = `
+Array [
+  "file:///{fs}/presm/dist/test/fixtures/yaml-build-basic/main.mjs",
+  "file:///{fs}/presm/dist/test/fixtures/yaml-build-basic/yamlExample.js",
+]
+`
+
 exports[`test/system/yaml.js TAP YAML System Tests > must match snapshot 1`] = `
 ### Resolving resource in basic resourceProvider for file:///{fs}/presm/test/fixtures/yamlTest.js
 

--- a/test/fixtures/loaderconfig5.json
+++ b/test/fixtures/loaderconfig5.json
@@ -1,0 +1,17 @@
+{
+  "inputDir": "test/fixtures/yaml-build-basic",
+  "outputDir": "dist",
+  "resourceProviders": [
+    {
+      "type": "../examples/loaders/resourceprovider-basic-fs.js",
+      "base": "./src"
+    }
+  ],
+  "preProcessors": [
+    {
+      "name": "../examples/loaders/preprocessor-yaml.js",
+      "options": {}
+    }
+  ],
+  "postProcessors": []
+}

--- a/test/fixtures/yaml-build-basic/main.mjs
+++ b/test/fixtures/yaml-build-basic/main.mjs
@@ -1,0 +1,3 @@
+import yamlFile from './yamlExample.yaml';
+
+console.log('YAML as JSON: \n', yamlFile);

--- a/test/fixtures/yaml-build-basic/yamlExample.yaml
+++ b/test/fixtures/yaml-build-basic/yamlExample.yaml
@@ -1,0 +1,13 @@
+# Some example YAML data
+Employees:
+  - John Doe:
+      job: SWE
+      skills:
+        - python
+        - java
+  - Jane Doe:
+      job: SWE
+      skills:
+        - java
+        - python
+        - php

--- a/test/system/yaml.js
+++ b/test/system/yaml.js
@@ -26,4 +26,35 @@ tap.test('YAML System Tests', async t => {
   );
 
   t.matchSnapshot(stdout);
+
+  // YAML Build Tests
+  // - simple transformation (YAML to JS)
+
+  function matchSnapshotSource(buildMap, msg) {
+    buildMap.forEach(fileSourcePair => {
+      t.matchSnapshot(fileSourcePair[1], msg);
+    });
+  }
+
+  function matchSnapshotFileURL(buildMap, msg) {
+    t.matchSnapshot(
+      buildMap.map(fileSourcePair => fileSourcePair[0].href),
+      msg
+    );
+  }
+  // Simple transpilation
+  let config = (await import('../../src/core.js')).getConfig(
+    './test/fixtures/loaderconfig5.json'
+  );
+
+  let generateBuildMap = (await import('../../src/build.js')).generateBuildMap;
+
+  let buildMap = await generateBuildMap(config);
+
+  matchSnapshotFileURL(
+    buildMap,
+    '[YAML Build] - Correct output tree file names'
+  );
+
+  matchSnapshotSource(buildMap, '[YAML Build] - Correct output source code');
 });


### PR DESCRIPTION
This PR aims to provide tests for the [build] functionality specifically for YAML transpilation builds

NOTE: that to successfully build and run files that import YAML as JSON, the YAML files must be converted to default exports in `.js` files - the tests reflect this intended functionality